### PR TITLE
7 - audience template

### DIFF
--- a/src/commands/api/templates/Template.service.ts
+++ b/src/commands/api/templates/Template.service.ts
@@ -53,7 +53,7 @@ const TemplateService = (config: Configstore) => {
   const CreateTemplate = async (template: Template): Promise<Template | null> => {
 
     try {
-      const response: Response = await baseService.Post('v3/templates', []);
+      const response: Response = await baseService.Post('v3/templates', template);
 
       if (response.ok) {
         const result: Template = (await response.json()) as Template;

--- a/src/commands/api/templates/TemplateType.ts
+++ b/src/commands/api/templates/TemplateType.ts
@@ -1,0 +1,5 @@
+export enum TemplateType {
+    Decision = 'DECISION',
+    Web = 'WEB',
+    Audience = 'AUDIENCE'
+}

--- a/src/utils/deploy/templates.ts
+++ b/src/utils/deploy/templates.ts
@@ -4,6 +4,7 @@ import { logline } from '../command-helpers.js';
 import { checkFolder, getFolderFiles, getFolders } from './helpers.js';
 import fs from 'fs';
 import { Template, TemplateElement } from '../../commands/api/templates/Template.interface.js';
+import { TemplateType } from '../../commands/api/templates/TemplateType.js'
 import Configstore from 'configstore';
 import { TemplateService } from '../../commands/api/templates/Template.service.js';
 import yaml from 'js-yaml';
@@ -27,8 +28,9 @@ const deployTemplates = async (artifactDirectory: string, config: Configstore) =
     return;
   }
 
-  await deployTemplateTypes(artifactDirectory, 'DECISION', config);
-  await deployTemplateTypes(artifactDirectory, 'WEB', config);
+  await deployTemplateTypes(artifactDirectory, TemplateType.Decision, config);
+  await deployTemplateTypes(artifactDirectory, TemplateType.Web, config);
+  await deployTemplateTypes(artifactDirectory, TemplateType.Audience, config);
 
   logline(chalk.greenBright(`Finished deploying templates`));
 };
@@ -187,9 +189,10 @@ const deployIndividualTemplates = async (
     } else {
       logline(chalk.greenBright(`Template ${template.friendlyId} does not exist in the tenant - will create`));
 
-      template.status = 'PUBLISHED';
+      // template.status = 'PUBLISHED';
 
-      result = templateService.CreateTemplate(template);
+      logline(JSON.stringify(template));
+      result = await templateService.CreateTemplate(template);
 
       if (result != null) {
         logline(chalk.greenBright(`Template ${template.friendlyId} successfully deployed`));

--- a/src/utils/deploy/templates.ts
+++ b/src/utils/deploy/templates.ts
@@ -191,7 +191,7 @@ const deployIndividualTemplates = async (
 
       // template.status = 'PUBLISHED';
 
-      logline(JSON.stringify(template));
+      // logline(JSON.stringify(template));
       result = await templateService.CreateTemplate(template);
 
       if (result != null) {


### PR DESCRIPTION
resolves #7 

Current APIs work with Audience templates

1. added audience templates
2. create TemplateType enum
3. pass in template to the create template call
4. added await on create template to fix timing
5. removed status overwrite on create template so that it doesn't overwrite from the file